### PR TITLE
`bundle install` note added to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Inside the newly created project, you can run some built-in commands:
 
 ### `npm start` or `yarn start`
 
+_Jekyll users will need to run `bundle install` first_
+
 Runs the app in development mode.<br>
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 


### PR DESCRIPTION
Jekyll users need to run `bundle install` first to install their gems otherwise C-S-S won't properly launch with `npm start`. I believe adding this to the Readme.md will help beginner users to troubleshoot their non-working C-S-S installation.